### PR TITLE
Replace rgl.* fns with *3d

### DIFF
--- a/R/bar3d.R
+++ b/R/bar3d.R
@@ -30,10 +30,10 @@ bar3d<-function(x=c(0,1),y=c(0,1),z,alpha=1,topcol="#078E53",sidecol="#aaaaaa",l
   y2=c(rep(y[1],4),rep(y[2],4),rep(c(rep(y[1],3),rep(y[2],3),y[1],y[2]),2) )
 
   ## These lines create the sides of the column and its colored top surface
-  rgl::rgl.quads(x1,z1,y1,col=rep(sidecol,each=4),alpha=alpha,lit=FALSE)
-  rgl::rgl.quads(c(x[1],x[2],x[2],x[1]),rep(z,4),c(y[1],y[1],y[2],y[2]),
+  rgl::quads3d(x1,z1,y1,col=rep(sidecol,each=4),alpha=alpha,lit=FALSE)
+  rgl::quads3d(c(x[1],x[2],x[2],x[1]),rep(z,4),c(y[1],y[1],y[2],y[2]),
             col=rep(topcol,each=4),alpha=1,lit=FALSE)
   ## Add colored edges to the column
-  rgl::rgl.lines(x2,z2,y2,col=linecol,lit=FALSE)
+  rgl::segments3d(x2,z2,y2,col=linecol,lit=FALSE)
   invisible()
 }

--- a/R/barplot3d.R
+++ b/R/barplot3d.R
@@ -87,7 +87,7 @@ barplot3d<-function(rows,cols,x,y,z,alpha=1,scalexy=1,gap=0.2,topcolors=c("#0000
     }
   }
   ## Set the viewpoint
-  rgl::rgl.viewpoint(theta=theta,phi=phi,fov=0)
+  rgl::view3d(theta=theta,phi=phi,fov=0)
 
   ## If desired, add grid lines, axes labels and axes subtitles
   if(gridlines){

--- a/vignettes/barplot3d.Rmd
+++ b/vignettes/barplot3d.Rmd
@@ -127,7 +127,7 @@ par3d(windowRect=c(0,50,600,450))
 rgl.snapsnot("filename.png")
 
 # If running multiple plots, you should close the viewing window
-rgl.close()
+close3d()
 ```
 
 ## Colors and transparency


### PR DESCRIPTION
Some upcoming changes to the rgl package will require changes to barplot3d. 
I will be deprecating a number of rgl.* function calls.  You can read 
about the issues here:

   https://dmurdoch.github.io/rgl/articles/deprecation.html

I have made the required changes in the attached patch file.